### PR TITLE
Fix bugs

### DIFF
--- a/_archiv/2023/classes/edirom.html
+++ b/_archiv/2023/classes/edirom.html
@@ -1,7 +1,7 @@
 ---
 title: Edirom für Einsteiger*innen
 title-short: Edirom
-label: teiE
+label: ediromE
 lang: deutsch
 costs: 25
 teachers:

--- a/_posts/2023-02-07-programm-online.md
+++ b/_posts/2023-02-07-programm-online.md
@@ -6,6 +6,6 @@ authors:
 - Dennis Ried
 ---
 
-Das [Kursprogramm](https://ess.upb.de/2023/programm.html) zur 14. Edirom Summer School ist online und richtet sich in diesem Jahr gezielt an Einsteiger\*innen. Natürlich können die Kurse auch zum Auffrischen genutzt werden, z. B. im Hinblick auf die TEI und MEC Joint Conference (4.–8. Sept. 2023).
+Das [Kursprogramm]({{ "2023/programm.html" | relative_url }}) zur 14. Edirom Summer School ist online und richtet sich in diesem Jahr gezielt an Einsteiger\*innen. Natürlich können die Kurse auch zum Auffrischen genutzt werden, z. B. im Hinblick auf die TEI und MEC Joint Conference (4.–8. Sept. 2023).
 
 Die Anmeldephase findet im Zeitraum vom **1. März** bis zum **29. Mai** statt.

--- a/_posts/2023-02-07-programm-online.md
+++ b/_posts/2023-02-07-programm-online.md
@@ -6,6 +6,6 @@ authors:
 - Dennis Ried
 ---
 
-Das Kursprogramm zur 14. Edirom Summer School ist online und richtet sich in diesem Jahr gezielt an Einsteiger\*innen. Natürlich können die Kurse auch zum Auffrischen genutzt werden, z. B. im Hinblick auf die TEI und MEC Joint Conference (4.–8. Sept. 2023).
+Das [Kursprogramm](https://ess.upb.de/2023/programm.html) zur 14. Edirom Summer School ist online und richtet sich in diesem Jahr gezielt an Einsteiger\*innen. Natürlich können die Kurse auch zum Auffrischen genutzt werden, z. B. im Hinblick auf die TEI und MEC Joint Conference (4.–8. Sept. 2023).
 
 Die Anmeldephase findet im Zeitraum vom **1. März** bis zum **29. Mai** statt.


### PR DESCRIPTION
Classes Edirom and TEI had the same label which produces a wrong linking of the class descriptions.
Also adding a missing link in the current post.