### PR TITLE
fix js for registration modal

### DIFF
--- a/_includes/registration-closed-overlay.html
+++ b/_includes/registration-closed-overlay.html
@@ -33,15 +33,9 @@
     </div>
     <script>
         let now = Date.now(),
-            anmeldebeginn = Date.parse('{{ page.registrationstart }}') ;
-        if(anmeldebeginn > now) {
-            $('#staticBackdrop').modal('show');
-        }
-    </script>
-    <script>
-        let now = Date.now(),
+            anmeldebeginn = Date.parse('{{ page.registrationstart }}'),
             anmeldeschluss = Date.parse('{{ page.deadline }}') ;
-        if(now > anmeldeschluss) {
+        if(anmeldebeginn > now || now > anmeldeschluss) {
             $('#staticBackdrop').modal('show');
         }
     </script>


### PR DESCRIPTION
this merges the two scripts into one, removing the issue "SyntaxError: Can't create duplicate variable: 'now'" and fixes #107