### PR TITLE
exclude Dependabot PRs from Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ jobs:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' 
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
GitHub Actions for these PRs initiated by Dependabot are always failing due to missing registry credentials. This PR adds a conditional that filters out Dependabot pushes