### PR TITLE
make the footer layout responsive

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,11 +1,11 @@
-<footer class="d-none d-lg-flex">
+<footer>
     <div class="container">
         <nav class="navbar fixed-bottom navbar-light bg-light navbar-expand-lg row">
-            <div class="col-md-3 text-center">
+            <div class="col-12 col-md-3 text-center">
                 <a class="m-1 text-decoration-none"
                    href="{{ '/impressum.html' | relative_url }}">Impressum</a>
             </div>
-            <div class="col-md-6 text-center">
+            <div class="col-12 col-md-6 text-center">
                 <a class="m-1" href="https://www.edirom.de"
                    target="_blank"><img
                         src="{{ '/assets/img/ViFE-logo-s.png' | relative_url }}"
@@ -20,7 +20,7 @@
                         alt="ZenMEM Logo"/></a>
             </div>
 
-            <div class="col-md-3 text-center">
+            <div class="col-12 col-md-3 text-center">
                 <a class="btn btn-primary mx-1 border-0 rounded-circle"
                    href="https://github.com/Edirom"
                    role="button"><i class="fab fa-github fa-2x"></i></a>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,7 +14,7 @@
                    target="_blank"><img
                        src="{{ '/assets/img/UPB_Logo_DE_vierfarbig_CMYK.png' | relative_url }}"
                         alt="Universität Paderborn Logo"/></a>
-                <a class="m-1" href="https://www.zenmem.de"
+                <a class="m-1" href="https://zenmem.uni-paderborn.de/"
                    target="_blank"><img
                         src="{{ '/assets/img/ZenMEM_dunkel.png' | relative_url }}"
                         alt="ZenMEM Logo"/></a>

--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -1,26 +1,37 @@
 // ESS-Farbvariablen laden (as * = kein Namespace-Präfix nötig)
 @use "ess-variables" as *;
+@use "bootstrap" as bootstrap;
+@use "sass:map";
 
 /*
  * Local layout variables — copied from Bootstrap defaults so footer
  * height calculation works without depending on Bootstrap internals.
  */
 $navbar-padding-y: 0.5rem;
-$footer-height: 4rem;
+$footer-height-xs: 9rem;   // 3 gestapelte Zeilen auf kleinen Screens
+$footer-height-md: 5rem;   // 2 Zeilen auf mittleren Screens
+$footer-height-lg: 4rem;   // 1 Zeile ab lg
 
 footer {
-  max-height: $footer-height;
   img {
-    max-height: $footer-height - 2 * $navbar-padding-y;
+    max-height: $footer-height-lg - 2 * $navbar-padding-y;
   }
 }
 
 /*
  * add margin-bottom according to
- * the sticky footer height
+ * the sticky footer height (responsive)
  */
 #main-content-container {
-  margin-bottom: $footer-height;
+  margin-bottom: $footer-height-xs;
+
+  @media (min-width: map.get(bootstrap.$grid-breakpoints, "md")) {
+    margin-bottom: $footer-height-md;
+  }
+
+  @media (min-width: map.get(bootstrap.$grid-breakpoints, "lg")) {
+    margin-bottom: $footer-height-lg;
+  }
 }
 
 /*

--- a/about.html
+++ b/about.html
@@ -29,7 +29,7 @@ title: "Über die Edirom Summer School"
                 Hochschule für Musik Detmold) organisiert – von 2013 bis 2017
                 außerdem in Kooperation und zusammen mit dem BMBF-Projekt <a href="https://portal-de.dariah.eu"
                     title="Digital Research Infrastructure for the Arts and Humanities">DARIAH-DE</a>
-                und seit 2014 in Kooperation mit dem <a href="https://zenmem.de"
+                und seit 2014 in Kooperation mit dem <a href="https://zenmem.uni-paderborn.de"
                     title="Zentrum Musik – Edition – Medien">Zentrum Musik –
                     Edition – Medien (ZenMEM)</a>.
             </p>

--- a/sponsors.html
+++ b/sponsors.html
@@ -43,7 +43,7 @@ card: false
             </div>
             
             <div class="col-10 col-sm-8 col-md-6 col-lg-4">
-                <a href="https://zenmem.de/"
+                <a href="https://zenmem.uni-paderborn.de"
                     target="_blank"><img width="500px" 
                         src="{{ '/assets/img/ZenMEM_dunkel.png' | relative_url }}" alt="ZenMEM Logo"
                          class="img-fluid"/></a>


### PR DESCRIPTION
This pull request updates the site's footer and related styles to improve responsiveness across different screen sizes and fixes outdated links to the ZenMEM website. The main changes include making the footer layout responsive, adjusting the footer height and content spacing for various devices, and updating ZenMEM URLs to their current domain.

**Footer Responsiveness and Layout Improvements:**

* Made the footer layout fully responsive by updating Bootstrap grid classes in `_includes/footer.html`, ensuring footer sections stack on small screens and align horizontally on larger screens.
* Adjusted footer height and image sizing in `_sass/app.scss` to use different heights for extra small, medium, and large screens, and updated the main content container's bottom margin to match the responsive footer height.
